### PR TITLE
Add support for the MediaPlayer1 hierarchy. 

### DIFF
--- a/examples/mediaplayer.js
+++ b/examples/mediaplayer.js
@@ -1,0 +1,29 @@
+const Bluez = require('..');
+
+const bluetooth = new Bluez();
+
+// This will only work if you already have a phone or other media
+// player paired and already connected to your computer, of course. For Linux,
+// checkout bluealsa as a very easy solution.
+
+// Register callback for new Media players
+bluetooth.on('mediaplayer', async (device, props) => {
+    var address = 'invalid';
+    console.log("[NEW] Mediaplayer:", device);
+
+    const player = await bluetooth.getMediaPlayer(device).catch(console.error);
+    player.on("PropertiesChanged", (props, invalidated) => {
+        console.log("[CHG] MediaPlayer:", device, props, invalidated);
+    });
+    player.on("interface-removed", () => {
+        console.log('[DEL] Player removed', device);
+        player.removeAllListeners();
+        delete mediaPlayers[address];
+        delete player;
+    })
+});
+
+bluetooth.init().then(async () => {
+    // listen on first bluetooth adapter
+    const adapter = await bluetooth.getAdapter();
+}).catch(console.error);

--- a/lib/Bluez.js
+++ b/lib/Bluez.js
@@ -109,13 +109,13 @@ class Bluez extends EventEmitter {
     }
 
     /**
-     * Get a Media player by device name.
+     * Get a Media player by path.
      * This searches all Adapters.
-     * @param {string} device 
+     * @param {string} path
      * @returns {Promise<MediaPlayer>}
      */
-    async getMediaPlayer(device) {
-        const res = await this.findInterfaceInstance(MediaPlayer.INTERFACE_NAME, MediaPlayer, (d) => d.Device === device);
+    async getMediaPlayer(path) {
+        const res = await this.getInterfaceInstance(path, MediaPlayer.INTERFACE_NAME, MediaPlayer);
         if (!res) throw new Error("Media player not found");
         return res;
     }
@@ -385,9 +385,8 @@ class Bluez extends EventEmitter {
         if ('org.bluez.MediaPlayer1' in interfaces) {
             const props = interfaces['org.bluez.MediaPlayer1'];
             // Note: there is no unique ID for a media player like the MAC
-            // address for a device, so we send the device back. This will
-            // not work if there are multiple media players on a given device
-            this.emit('mediaplayer', props.Device, props);
+            // address for a device, so we use the path, which is unique.
+            this.emit('mediaplayer', path, props);
         }
     }
 

--- a/lib/Bluez.js
+++ b/lib/Bluez.js
@@ -5,6 +5,7 @@ const util = require('util');
 const Adapter = require('./Adapter');
 const Device = require('./Device');
 const Agent = require('./Agent');
+const MediaPlayer = require('./MediaPlayer');
 const StaticKeyAgent = require('./StaticKeyAgent');
 const Profile = require('./Profile');
 const SerialProfile = require('./SerialProfile');
@@ -107,6 +108,17 @@ class Bluez extends EventEmitter {
         return Object.values(devProps);
     }
 
+    /**
+     * Get a Media player by device name.
+     * This searches all Adapters.
+     * @param {string} device 
+     * @returns {Promise<MediaPlayer>}
+     */
+    async getMediaPlayer(device) {
+        const res = await this.findInterfaceInstance(MediaPlayer.INTERFACE_NAME, MediaPlayer, (d) => d.Device === device);
+        if (!res) throw new Error("Media player not found");
+        return res;
+    }
 
     /*
     This registers a profile implementation.
@@ -357,7 +369,7 @@ class Bluez extends EventEmitter {
         let next = this.tree;
         for (const p of path.split("/")) {
             if (!p) continue;
-            //console.log(p, next);
+            // console.log(p, next);
             if (!next[p]) {
                 next[p] = {};
             }
@@ -369,10 +381,17 @@ class Bluez extends EventEmitter {
             const props = interfaces['org.bluez.Device1'];
             this.emit('device', props.Address, props);
         }
+
+        if ('org.bluez.MediaPlayer1' in interfaces) {
+            const props = interfaces['org.bluez.MediaPlayer1'];
+            // Note: there is no unique ID for a media player like the MAC
+            // address for a device, so we send the device back. This will
+            // not work if there are multiple media players on a given device
+            this.emit('mediaplayer', props.Device, props);
+        }
     }
 
     async onInterfaceRemoved(path, interfaces/*:string[]*/) {
-        //console.log("Interface Removed", path, interfaces)
 
         let next = this.tree;
         for (const p of path.split("/")) {
@@ -386,7 +405,9 @@ class Bluez extends EventEmitter {
         if (next._interfaces) {
             for (const intf of interfaces) {
                 if (next._interfaces[intf] && next._interfaces[intf]._instance) {
-                    // TODO: warning ???
+                    // Warning: if there are listeners registered for that interface,
+                    // they will need to listen for "interface-removed" and remove
+                    // all listeners.
                     next._interfaces[intf]._instance.emit("interface-removed");
                 }
                 delete next._interfaces[intf];

--- a/lib/MediaPlayer.js
+++ b/lib/MediaPlayer.js
@@ -1,0 +1,356 @@
+const DbusInterfaceBase = require("./DbusInterfaceBase");
+
+class MediaPlayer extends DbusInterfaceBase {
+
+    /*
+    Resume playback.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Play() {
+        return new Promise((resolve, reject) => {
+            this._interface.Play((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /*
+    Pause playback.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Pause() {
+        return new Promise((resolve, reject) => {
+            this._interface.Play((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+                
+    /*
+    Stop playback.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Stop() {
+        return new Promise((resolve, reject) => {
+            this._interface.Stop((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+                
+    /*
+    Next item.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Next() {
+        return new Promise((resolve, reject) => {
+            this._interface.Next((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /*
+    Previous item.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Previous() {
+        return new Promise((resolve, reject) => {
+            this._interface.Previous((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /*
+    Fast forward playback, this action is only stopped
+    when another method in this interface is called.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    FastForward() {
+        return new Promise((resolve, reject) => {
+            this._interface.FastForward((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+                    
+    /*
+    Rewind playback, this action is only stopped
+    when another method in this interface is called.
+
+    Possible Errors: org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Rewind() {
+        return new Promise((resolve, reject) => {
+            this._interface.Rewind((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /*
+    Press a specific key to send as passthrough command.
+    The key will be released automatically. Use Hold()
+    instead if the intention is to hold down the key.
+
+    Possible Errors: org.bluez.Error.InvalidArguments
+					 org.bluez.Error.NotSupported
+					 org.bluez.Error.Failed
+    */
+    Press(avc_key) {
+        return new Promise((resolve, reject) => {
+            this._interface.Press(avc_key, (err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /*
+    Press and hold a specific key to send as passthrough
+    command. It is your responsibility to make sure that
+    Release() is called after calling this method. The held
+    key will also be released when any other method in this
+    interface is called.
+    */
+    Hold(avc_key) {
+        return new Promise((resolve, reject) => {
+            this._interface.Hold(avc_key, (err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /*
+    Release the previously held key invoked using Hold().
+    */
+    Release() {
+        return new Promise((resolve, reject) => {
+            this._interface.Release((err) => {
+                if (err) return reject(err);
+                resolve();
+            })
+        });
+    }
+
+    /****** Properties ******/
+
+    /*
+    string Equalizer [readwrite]
+    
+        Possible values: "off" or "on"
+    */
+    Equalizer(value) {
+        if (value !== undefined) {
+            return this.setProperty("Equalizer", value);
+        }
+        return this.getProperty("Equalizer");
+    }
+
+    /*
+    string Repeat [readwrite]
+    Possible values: "off", "singletrack", "alltracks" or
+					"group"
+    */
+    Repeat(value) {
+        if (value !== undefined) {
+            return this.setProperty("Repeat", value);
+        }
+        return this.getProperty("Repeat");
+    }
+
+    /*
+    string Shuffle [readwrite]
+    Possible values: "off", "alltracks" or "group"
+    */
+    Shuffle(value) {
+        if (value !== undefined) {
+            return this.setProperty("Shuffle", value);
+        }
+        return this.getProperty("Shuffle");
+    }
+
+    /*
+    string Scan [readwrite]
+    Possible values: "off", "alltracks" or "group"
+    */
+    Scan(value) {
+        if (value !== undefined) {
+            return this.setProperty("Scan", value);
+        }
+        return this.getProperty("Scan");
+    }
+
+    /*
+    string Status [readonly]
+    Possible status: "playing", "stopped", "paused",
+					"forward-seek", "reverse-seek"
+					or "error"
+    */
+    Status() {
+        return this.getProperty("Status");
+    }
+
+
+    /*
+    uint32 Position [readonly]
+
+    Playback position in milliseconds. Changing the
+    position may generate additional events that will be
+    sent to the remote device. When position is 0 it means
+    the track is starting and when it's greater than or
+    equal to track's duration the track has ended. Note
+    that even if duration is not available in metadata it's
+    possible to signal its end by setting position to the
+    maximum uint32 value.
+    */
+    Position() {
+        return this.getProperty("Position");
+    }
+
+    /*
+    dict Track [readonly]
+
+			Track metadata.
+			Possible values:
+				string Title:
+					Track title name
+				string Artist:
+					Track artist name
+				string Album:
+					Track album name
+				string Genre:
+					Track genre name
+				uint32 NumberOfTracks:
+					Number of tracks in total
+				uint32 TrackNumber:
+					Track number
+				uint32 Duration:
+					Track duration in milliseconds
+    */
+    Track() {
+        return this.getProperty("Track");
+    }
+
+    /*
+    object Device [readonly]
+
+			Device object path.
+    */
+    Device() {
+        return this.getProperty("Device");
+    }
+                        
+    /*
+    string Name [readonly]
+
+			Player name
+    */
+    Name() {
+        return this.getProperty("Name");
+    }
+
+    /*
+    string Type [readonly]
+
+    Player type
+
+    Possible values:
+
+        "Audio"
+        "Video"
+        "Audio Broadcasting"
+        "Video Broadcasting"
+    */
+    Type() {
+        return this.getProperty("Type");
+    }
+
+    /*
+    string Subtype [readonly]
+
+    Player subtype
+
+    Possible values:
+
+        "Audio Book"
+        "Podcast"
+    */
+    Subtype() {
+        return this.getProperty("Subtype");
+    }
+
+    /*
+    boolean Browsable [readonly]
+
+    If present indicates the player can be browsed using
+    MediaFolder interface.
+
+    Possible values:
+
+        True: Supported and active
+        False: Supported but inactive
+
+    Note: If supported but inactive clients can enable it
+    by using MediaFolder interface but it might interfere
+    in the playback of other players.
+    */
+    Browsable() {
+        return this.getProperty("Browsable");
+    }
+
+    /*
+    boolean Searchable [readonly]
+
+    If present indicates the player can be searched using
+    MediaFolder interface.
+
+    Possible values:
+
+        True: Supported and active
+        False: Supported but inactive
+
+    Note: If supported but inactive clients can enable it
+    by using MediaFolder interface but it might interfere
+    in the playback of other players.
+    */
+    Searchable() {
+        return this.getProperty("Searchable");
+    }
+
+    /*
+    object Playlist
+
+			Playlist object path.
+    */
+    Playlist() {
+        return this.getProperty("Playlist");
+    }
+        
+}
+
+MediaPlayer.INTERFACE_NAME = "org.bluez.MediaPlayer1";
+
+module.exports = MediaPlayer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,18 +175,11 @@
       }
     },
     "dbus": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/dbus/-/dbus-1.0.5.tgz",
-      "integrity": "sha512-itMup/0lcjnwV4DULJtI8q37Nky713KE2b1QM4+W/0zlzAsMNJZURBtyENtnJc6BlHouqbur++PXWeEKDuGulg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/dbus/-/dbus-1.0.7.tgz",
+      "integrity": "sha512-qba6/ajLoqzCy3Kl3aFgLXLP4TTf0qfgNjib1qoCJG/8HbSs0lDvxkz4nJU63CURZVzxvpK/VpQpT40KA8Kr3A==",
       "requires": {
-        "nan": "^2.13.2"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        }
+        "nan": "^2.14.0"
       }
     },
     "delayed-stream": {


### PR DESCRIPTION
Works great for receiving track info from connected devices. Included example. LMK if this can be added to the main codebase.

The only issue I can see is that MediaPlayers don't have a unique MAC like devices, so I'm using the device path for the media player as the reference. It would be interesting to find a device that provides multiple mediaplayer endpoints, not sure there are any.